### PR TITLE
Add mpv installation instruction

### DIFF
--- a/shelldio.sh
+++ b/shelldio.sh
@@ -118,12 +118,28 @@ remove_station() {
 			elif [ "$remove_station" -gt 0 ] && [ "$remove_station" -le $num ]; then #έλεγχος αν το input είναι μέσα στο εύρος της λίστας των σταθμών
 				station=$(sed "${remove_station}q;d" "$my_stations")
 				stathmos_name=$(echo "$station" | cut -d "," -f1)
-				grep -v "$stathmos_name" "$HOME/.shelldio/my_stations.txt" > "$HOME/.shelldio/my_stations.tmp" && mv "$HOME/.shelldio/my_stations.tmp" "$HOME/.shelldio/my_stations.txt"
+				grep -v "$stathmos_name" "$HOME/.shelldio/my_stations.txt" >"$HOME/.shelldio/my_stations.tmp" && mv "$HOME/.shelldio/my_stations.tmp" "$HOME/.shelldio/my_stations.txt"
 				echo "Διαγράφηκε ο σταθμός $stathmos_name."
 			else
 				echo "Αριθμός εκτός λίστας"
 			fi
 		done
+	fi
+}
+
+mpv_msg() {
+	if grep debian /etc/os-release &> /dev/null; then
+		echo "Τρέξτε 'sudo apt install mpv' για να εγκαταστήσετε τον player"
+	elif grep fedora /etc/os-release &> /dev/null; then
+		echo "Τρέξτε 'sudo dnf -y install mpv' για να εγκαταστήσετε τον player"
+	elif grep suse /etc/os-release &> /dev/null; then
+		echo "Τρέξτε 'sudo zypper in mpv' για να εγκαταστήσετε τον player"
+	elif grep centos /etc/os-release &> /dev/null; then
+		echo "Τρέξτε 'sudo yum -y install mpv' για να εγκαταστήσετε τον player"
+	elif uname -a | grep Darwin &> /dev/null; then
+		echo "Τρέξτε 'sudo brew install mpv' για να εγκαταστήσετε τον player"
+	else
+		echo "https://github.com/mpv-player/mpv/releases/latest"
 	fi
 }
 
@@ -192,6 +208,7 @@ if [[ $player = 1 ]]; then
 	echo "Έλεγχος προαπαιτούμενων για το Shelldio"
 	sleep 1
 	echo -e "Το Shelldio χρειάζεται το MPV player αλλά δεν βρέθηκε στο σύστημά σας.\nΠαρακαλούμε εγκαταστήστε το MPV πριν τρέξετε το Shelldio"
+	mpv_msg
 	exit 1
 fi
 for binary in grep curl info sleep clear killall; do


### PR DESCRIPTION
Τωρα είναι μέρος του script.

παράδειγμα σε fedora:

```shell
[root@e12eec40a60f /]# ./shelldio.sh
Έλεγχος προαπαιτούμενων για το Shelldio
Το Shelldio χρειάζεται το MPV player αλλά δεν βρέθηκε στο σύστημά σας.
Παρακαλούμε εγκαταστήστε το MPV πριν τρέξετε το Shelldio
Τρέξτε 'sudo dnf -y install mpv' για να εγκαταστήσετε τον player
```