### PR TITLE
Αφαίρεση παραμέτρων από το tput για την απόκρυψη/εμφάνιση του cursor …

### DIFF
--- a/.shelldio/all_stations.txt
+++ b/.shelldio/all_stations.txt
@@ -62,7 +62,6 @@ Mythos Athens,http://bestgreek.info:8104
 North 98,https://netradio.live24.gr/north98thess
 Nostos 100.6,https://neos.win:37878/stream
 Off Radio,http://46.28.53.118:7062/stream
-Overfm Athens 104.9,https://netradio.live24.gr/overfm-internet
 Party FM 104,https://radio.streamings.gr:9006/stream
 Pepper 96.6,https://pepper966.live24.gr/pepperorigin
 Piqeras DeeJay 105.6,http://rosetta.shoutca.st:8270/stream

--- a/shelldio.sh
+++ b/shelldio.sh
@@ -137,7 +137,8 @@ list_stations() {
 # Πληροφορίες που εμφανίζονται μετά την επιλογή του σταθμού
 info() {
 	welcome_screen
-	tput civis -- invisible # Απόκρυψη cursor
+
+	tput civis # Εξαφάνιση cursor
 	echo -ne "  Σταθμός: [$selected_play]    Η ώρα είναι $(date +"%T")\n"
 	echo -ne " \n"
 	echo -ne "  Ακούτε: $stathmos_name\n"
@@ -453,7 +454,7 @@ while true; do
 
 		if [[ $input_play = "q" ]] || [[ $input_play = "Q" ]]; then
 			echo "Έξοδος..."
-			tput cnorm -- normal # Εμφάνιση cursor
+			tput cnorm # Εμφάνιση cursor
 			exit 0
 		elif [ "$input_play" -gt 0 ] && [ "$input_play" -le $num ]; then #έλεγχος αν το input είναι μέσα στο εύρος της λίστας των σταθμών
 			station=$(sed "${input_play}q;d" "$stations")
@@ -479,14 +480,14 @@ while true; do
 		if [[ $input_play = "q" ]] || [[ $input_play = "Q" ]]; then
 			clear
 			echo "Έξοδος..."
-			tput cnorm -- normal # Εμφάνιση cursor
+			tput cnorm # Εμφάνιση cursor
 			exit 0
 		elif [[ $input_play = "r" ]] || [[ $input_play = "R" ]]; then
 			for pid in $(pgrep '^mpv$'); do
 				url="$(ps -o command= -p "$pid" | awk '{print $2}')"
 				if [[ "$url" == "$stathmos_url" ]]; then
 					echo "Έξοδος..."
-					tput cnorm -- normal # Εμφάνιση cursor
+					tput cnorm # Εμφάνιση cursor
 					kill "$pid"
 				else
 					printf "Απέτυχε ο αυτόματος τερματισμός. \nΠάτα τον συνδυασμό Ctrl+C ή κλείσε το τερματικό \nή τερμάτισε το Shelldio απο τις διεργασίες του συστήματος"
@@ -494,7 +495,7 @@ while true; do
 			done
 			clear
 			echo "Επιστροφή στη λίστα σταθμών"
-			tput cnorm -- normal # Εμφάνιση cursor
+			tput cnorm # Εμφάνιση cursor
 			sleep 1
 			clear
 			break


### PR DESCRIPTION
…(#125)

* Revert "Προσθήκη Overfm 104.6 #101"

This reverts commit 8bb71aa34ba71e71b36ce4525580ba9bc8468d7c.

* Προσθήκη τερματισμού μετά την αναβάθμιση

* Revert "Προσθήκη τερματισμού μετά την αναβάθμιση"

This reverts commit 22af6fb3cea8bff18ecf3f8672b5493df77df3bb.

* Διόρθωση εμφάνιση y/n διαλόγου

* Διόρθωση παραμέτρου στο tput

Co-authored-by: Salih Emin <cerebrux@users.noreply.github.com>